### PR TITLE
Do not redirect to undefined

### DIFF
--- a/src/Http/Controllers/Saml2Controller.php
+++ b/src/Http/Controllers/Saml2Controller.php
@@ -70,7 +70,7 @@ class Saml2Controller extends Controller
 
         $this->unsetRequest();
 
-        if ($redirectUrl) {
+        if (filled($redirectUrl) && $redirectUrl !== 'undefined') {
             return redirect($redirectUrl);
         }
 


### PR DESCRIPTION
In some cases, RelayState may not be defined in the IdP.

If not provided, the value becomes undefined, putting the user in an undesired state (my-app.com/undefined).

This adds better handling of RelayState and provides a fallback to the configured loginRoute.